### PR TITLE
feat: Migrate from NGINX to Istio Gateway for External Ingress

### DIFF
--- a/istio-migration/README.md
+++ b/istio-migration/README.md
@@ -1,0 +1,30 @@
+# Istio Migration Plan
+
+This PR transitions the home cluster from using NGINX as the primary ingress controller to Istio Gateway API.
+
+## Implementation Steps
+
+1. Apply the wildcard certificate for Istio ingress
+2. Update the Gateway configuration to handle all cluster ingress traffic
+3. Update cloudflared configuration to point to Istio instead of NGINX
+4. Create VirtualServices for external services (minio-ui, proxmox)
+5. Update external-dns configuration to work with Istio Gateway API
+6. Test the migration with a few services first
+7. Gradually migrate all services to VirtualServices
+8. Decommission NGINX ingress after successful migration
+
+## Components Updated
+
+- Istio Gateway
+- Cloudflared tunnel configuration
+- External-DNS configuration
+- Certificate management
+- Service ingress definitions
+
+## Testing Plan
+
+1. Verify certificate issuance for Istio gateway
+2. Confirm Cloudflare DNS records are properly created
+3. Test external services (minio-ui, proxmox) through Istio gateway
+4. Monitor logs for connectivity issues
+5. Validate authentication continues to work properly

--- a/istio-migration/cloudflared-config.yaml
+++ b/istio-migration/cloudflared-config.yaml
@@ -1,0 +1,13 @@
+---
+originRequest:
+  http2Origin: true
+ingress:
+  - hostname: ${SECRET_DOMAIN}
+    service: https://istio-gateway.istio-ingress.svc.cluster.local:443
+    originRequest:
+      originServerName: external.${SECRET_DOMAIN}
+  - hostname: "*.${SECRET_DOMAIN}"
+    service: https://istio-gateway.istio-ingress.svc.cluster.local:443
+    originRequest:
+      originServerName: external.${SECRET_DOMAIN}
+  - service: http_status:404

--- a/istio-migration/external-dns-values.yaml
+++ b/istio-migration/external-dns-values.yaml
@@ -1,0 +1,15 @@
+---
+# Updates for external-dns to work with Istio gateway/virtual services
+extraArgs:
+  - --provider=cloudflare
+  - --source=istio-gateway
+  - --source=istio-virtualservice
+  - --source=crd
+  - --cloudflare-proxied
+  - --crd-source-apiversion=externaldns.k8s.io/v1alpha1
+  - --crd-source-kind=DNSEndpoint
+policy: sync
+sources: [istio-gateway, istio-virtualservice, crd]
+txtPrefix: k8s.
+txtOwnerId: default
+domainFilters: ["${SECRET_DOMAIN}"]

--- a/istio-migration/gateway.yaml
+++ b/istio-migration/gateway.yaml
@@ -1,0 +1,26 @@
+---
+# kubernetes/apps/istio-ingress/gateway/app/gateway.yaml
+apiVersion: networking.istio.io/v1beta1
+kind: Gateway
+metadata:
+  name: external-gateway
+  namespace: istio-ingress
+spec:
+  selector:
+    istio: ingressgateway
+  servers:
+    - port:
+        number: 80
+        name: http
+        protocol: HTTP
+      hosts: ["external.${SECRET_DOMAIN}", "*.${SECRET_DOMAIN}"]
+      tls:
+        httpsRedirect: true  # Redirect all HTTP traffic to HTTPS
+    - port:
+        number: 443
+        name: https
+        protocol: HTTPS
+      tls:
+        mode: SIMPLE
+        credentialName: ${SECRET_DOMAIN/./-}-production-tls
+      hosts: ["external.${SECRET_DOMAIN}", "*.${SECRET_DOMAIN}"]

--- a/istio-migration/kustomization.yaml
+++ b/istio-migration/kustomization.yaml
@@ -1,0 +1,17 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - wildcard-certificate.yaml
+  - gateway.yaml
+  - minio-virtualservice.yaml
+  - pve-virtualservice.yaml
+
+configMapGenerator:
+  - name: cloudflared-configmap
+    namespace: networking
+    files:
+      - config.yaml=cloudflared-config.yaml
+
+patchesStrategicMerge:
+  - external-dns-values.yaml

--- a/istio-migration/minio-virtualservice.yaml
+++ b/istio-migration/minio-virtualservice.yaml
@@ -1,0 +1,18 @@
+---
+apiVersion: networking.istio.io/v1beta1
+kind: VirtualService
+metadata:
+  name: minio-ui
+  namespace: networking
+  annotations:
+    external-dns/is-public: "true"
+    external-dns.alpha.kubernetes.io/target: external.${SECRET_DOMAIN}
+spec:
+  hosts: ["minio.${SECRET_DOMAIN}"]
+  gateways: [istio-ingress/external-gateway]
+  http:
+    - route:
+        - destination:
+            host: minio-ui.networking.svc.cluster.local
+            port:
+              number: 9769

--- a/istio-migration/pve-virtualservice.yaml
+++ b/istio-migration/pve-virtualservice.yaml
@@ -1,0 +1,21 @@
+---
+apiVersion: networking.istio.io/v1beta1
+kind: VirtualService
+metadata:
+  name: pve
+  namespace: networking
+  annotations:
+    external-dns/is-public: "true"
+    external-dns.alpha.kubernetes.io/target: external.${SECRET_DOMAIN}
+spec:
+  hosts: ["pve.${SECRET_DOMAIN}"]
+  gateways: [istio-ingress/external-gateway]
+  http:
+    - route:
+        - destination:
+            host: pve.networking.svc.cluster.local
+            port:
+              number: 8006
+      tls:
+        mode: SIMPLE
+        sniHosts: ["pve.${SECRET_DOMAIN}"]

--- a/istio-migration/wildcard-certificate.yaml
+++ b/istio-migration/wildcard-certificate.yaml
@@ -1,0 +1,15 @@
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: ${SECRET_DOMAIN/./-}-production
+  namespace: istio-ingress
+spec:
+  secretName: ${SECRET_DOMAIN/./-}-production-tls
+  issuerRef:
+    name: letsencrypt-production
+    kind: ClusterIssuer
+  commonName: "*.${SECRET_DOMAIN}"
+  dnsNames:
+    - "*.${SECRET_DOMAIN}"
+    - "${SECRET_DOMAIN}"

--- a/kubernetes/apps/istio-ingress/gateway/app/gateway.yaml
+++ b/kubernetes/apps/istio-ingress/gateway/app/gateway.yaml
@@ -7,15 +7,15 @@ metadata:
   namespace: istio-ingress
 spec:
   selector:
-    istio: istio-gateway
+    istio: ingressgateway
   servers:
     - port:
         number: 80
         name: http
         protocol: HTTP
       hosts: ["external.${SECRET_DOMAIN}", "*.${SECRET_DOMAIN}"]
-      # tls:
-      #   httpsRedirect: true  # Redirect all HTTP traffic to HTTPS
+      tls:
+        httpsRedirect: true  # Redirect all HTTP traffic to HTTPS
     - port:
         number: 443
         name: https

--- a/kubernetes/apps/istio-ingress/gateway/app/wildcard-certificate.yaml
+++ b/kubernetes/apps/istio-ingress/gateway/app/wildcard-certificate.yaml
@@ -1,0 +1,15 @@
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: ${SECRET_DOMAIN/./-}-production
+  namespace: istio-ingress
+spec:
+  secretName: ${SECRET_DOMAIN/./-}-production-tls
+  issuerRef:
+    name: letsencrypt-production
+    kind: ClusterIssuer
+  commonName: "*.${SECRET_DOMAIN}"
+  dnsNames:
+    - "*.${SECRET_DOMAIN}"
+    - "${SECRET_DOMAIN}"

--- a/kubernetes/apps/networking/cloudflared/app/configs/config.yaml
+++ b/kubernetes/apps/networking/cloudflared/app/configs/config.yaml
@@ -3,12 +3,11 @@ originRequest:
   http2Origin: true
 ingress:
   - hostname: ${SECRET_DOMAIN}
-    service: https://nginx-external-controller.networking.svc.cluster.local:443
+    service: https://istio-gateway.istio-ingress.svc.cluster.local:443
     originRequest:
       originServerName: external.${SECRET_DOMAIN}
   - hostname: "*.${SECRET_DOMAIN}"
-    service: https://nginx-external-controller.networking.svc.cluster.local:443
-    # service: https://istio-ingressgateway.istio-system:443
+    service: https://istio-gateway.istio-ingress.svc.cluster.local:443
     originRequest:
       originServerName: external.${SECRET_DOMAIN}
   - service: http_status:404

--- a/kubernetes/apps/networking/external-dns/app/helmrelease.yaml
+++ b/kubernetes/apps/networking/external-dns/app/helmrelease.yaml
@@ -34,12 +34,13 @@ spec:
             name: external-dns-secret
             key: api-token
     extraArgs:
-      - --ingress-class=external
       - --cloudflare-proxied
       - --crd-source-apiversion=externaldns.k8s.io/v1alpha1
       - --crd-source-kind=DNSEndpoint
+      - --source=istio-gateway
+      - --source=istio-virtualservice
     policy: sync
-    sources: [crd, ingress]
+    sources: [crd, istio-gateway, istio-virtualservice]
     txtPrefix: k8s.
     txtOwnerId: default
     domainFilters: ["${SECRET_DOMAIN}"]

--- a/kubernetes/apps/networking/external-services/app/kustomization.yaml
+++ b/kubernetes/apps/networking/external-services/app/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - minio-virtualservice.yaml
+  - pve-virtualservice.yaml

--- a/kubernetes/apps/networking/external-services/app/minio-virtualservice.yaml
+++ b/kubernetes/apps/networking/external-services/app/minio-virtualservice.yaml
@@ -1,0 +1,18 @@
+---
+apiVersion: networking.istio.io/v1beta1
+kind: VirtualService
+metadata:
+  name: minio-ui
+  namespace: networking
+  annotations:
+    external-dns/is-public: "true"
+    external-dns.alpha.kubernetes.io/target: external.${SECRET_DOMAIN}
+spec:
+  hosts: ["minio.${SECRET_DOMAIN}"]
+  gateways: [istio-ingress/external-gateway]
+  http:
+    - route:
+        - destination:
+            host: minio-ui.networking.svc.cluster.local
+            port:
+              number: 9769

--- a/kubernetes/apps/networking/external-services/app/pve-virtualservice.yaml
+++ b/kubernetes/apps/networking/external-services/app/pve-virtualservice.yaml
@@ -1,0 +1,21 @@
+---
+apiVersion: networking.istio.io/v1beta1
+kind: VirtualService
+metadata:
+  name: pve
+  namespace: networking
+  annotations:
+    external-dns/is-public: "true"
+    external-dns.alpha.kubernetes.io/target: external.${SECRET_DOMAIN}
+spec:
+  hosts: ["pve.${SECRET_DOMAIN}"]
+  gateways: [istio-ingress/external-gateway]
+  http:
+    - route:
+        - destination:
+            host: pve.networking.svc.cluster.local
+            port:
+              number: 8006
+      tls:
+        mode: SIMPLE
+        sniHosts: ["pve.${SECRET_DOMAIN}"]

--- a/kubernetes/apps/networking/external-services/ks.yaml
+++ b/kubernetes/apps/networking/external-services/ks.yaml
@@ -1,0 +1,16 @@
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: cluster-apps-networking-external-services
+  namespace: flux-system
+spec:
+  path: ./kubernetes/apps/networking/external-services/app
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: home-kubernetes
+  wait: true
+  interval: 30m
+  retryInterval: 1m
+  timeout: 5m

--- a/kubernetes/apps/networking/kustomization.yaml
+++ b/kubernetes/apps/networking/kustomization.yaml
@@ -9,3 +9,4 @@ resources:
   - ./nginx/ks.yaml
   - ./tailscale-operator/ks.yaml
   - ./tailscale-connector/ks.yaml
+  - ./external-services/ks.yaml


### PR DESCRIPTION
## Summary
- Implement Istio Gateway API for external service ingress, replacing NGINX
- Configure VirtualServices for external services (minio, proxmox)
- Update cloudflared to point to Istio gateway
- Configure external-dns to work with Istio resources
- Add wildcard certificate for TLS termination at Istio gateway

## Test plan
1. Verify certificate issuance for Istio gateway
2. Confirm DNS records are properly created in Cloudflare
3. Test external services (minio-ui, proxmox) still work with Istio gateway
4. Validate authentication continues to function properly

🤖 Generated with [Claude Code](https://claude.ai/code)