### PR TITLE
add renovate autoMerge

### DIFF
--- a/.github/renovate/autoMerge.json5
+++ b/.github/renovate/autoMerge.json5
@@ -16,6 +16,54 @@
       "automerge": true,
       "automergeType": "branch",
       "matchUpdateTypes": ["minor", "patch"]
+    },
+    {
+      "description": ["Auto-merge Helm charts for patch updates"],
+      "matchDatasources": ["helm"],
+      "automerge": true,
+      "automergeType": "branch",
+      "matchUpdateTypes": ["patch"],
+      "ignoreTests": true
+    },
+    {
+      "description": ["Auto-merge trusted container images for minor and patch updates"],
+      "matchDatasources": ["docker"],
+      "automerge": true,
+      "automergeType": "branch",
+      "matchUpdateTypes": ["minor", "patch"],
+      "matchPackagePatterns": [
+        "ghcr.io/bjw-s",
+        "ghcr.io/onedr0p",
+        "ghcr.io/fluxcd",
+        "quay.io/prometheus",
+        "grafana/grafana",
+        "postgres",
+        "redis",
+        "nginx"
+      ],
+      "ignoreTests": true
+    },
+    {
+      "description": ["Auto-merge stable Kubernetes operators for patch updates"],
+      "matchDatasources": ["docker", "helm"],
+      "automerge": true,
+      "automergeType": "branch",
+      "matchUpdateTypes": ["patch"],
+      "matchPackagePatterns": [
+        "cloudnative-pg",
+        "cert-manager",
+        "external-dns",
+        "ingress-nginx"
+      ],
+      "ignoreTests": true
+    },
+    {
+      "description": ["Auto-merge GitHub releases for patch updates"],
+      "matchDatasources": ["github-releases", "github-tags"],
+      "automerge": true,
+      "automergeType": "branch",
+      "matchUpdateTypes": ["patch"],
+      "ignoreTests": true
     }
   ]
 }


### PR DESCRIPTION
This pull request updates the `.github/renovate/autoMerge.json5` file to enhance the auto-merge configuration for specific types of dependencies. The main changes include adding new rules to enable auto-merging for Helm charts, trusted container images, stable Kubernetes operators, and GitHub releases.

### Enhancements to auto-merge configuration:

* Added a rule to auto-merge Helm chart updates for patch versions, with tests ignored.
* Added a rule to auto-merge trusted container images (e.g., `ghcr.io/bjw-s`, `grafana/grafana`, `postgres`) for minor and patch updates, with tests ignored.
* Added a rule to auto-merge stable Kubernetes operators (e.g., `cert-manager`, `ingress-nginx`) for patch updates, with tests ignored.
* Added a rule to auto-merge GitHub release updates for patch versions, with tests ignored.