### PR TITLE
feat: Add Telepresence OSS GitOps deployment

### DIFF
--- a/kubernetes/apps/telepresence/kustomization.yaml
+++ b/kubernetes/apps/telepresence/kustomization.yaml
@@ -1,0 +1,4 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources: [./namespace.yaml, ./telepresence-oss/ks.yaml]

--- a/kubernetes/apps/telepresence/namespace.yaml
+++ b/kubernetes/apps/telepresence/namespace.yaml
@@ -1,0 +1,8 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: telepresence
+  labels:
+    kustomize.toolkit.fluxcd.io/prune: disabled
+    istio-injection: enabled

--- a/kubernetes/apps/telepresence/telepresence-oss/app/helmrelease.yaml
+++ b/kubernetes/apps/telepresence/telepresence-oss/app/helmrelease.yaml
@@ -1,0 +1,113 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/fluxcd/helm-controller/main/docs/api/v2/helmrelease.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: &app my-telepresence-oss
+  namespace: telepresence
+spec:
+  interval: 30m
+  chart:
+    spec:
+      chart: telepresence-oss
+      version: 2.23.6
+      sourceRef:
+        kind: HelmRepository
+        name: telepresence
+        namespace: flux-system
+  install:
+    remediation:
+      retries: 3
+  upgrade:
+    cleanupOnFail: true
+    remediation:
+      strategy: rollback
+      retries: 3
+  values:
+    # Telepresence OSS configuration
+    # The chart provides sensible defaults for most configurations
+
+    # Traffic Manager configuration
+    trafficManager:
+      # Enable the traffic manager
+      enabled: true
+
+      # Resource limits and requests
+      resources:
+        requests:
+          cpu: 100m
+          memory: 128Mi
+        limits:
+          cpu: 500m
+          memory: 512Mi
+
+      # Security context
+      securityContext:
+        allowPrivilegeEscalation: false
+        readOnlyRootFilesystem: true
+        runAsNonRoot: true
+        runAsUser: 1000
+        runAsGroup: 1000
+        capabilities:
+          drop: [ALL]
+
+      # Pod security context
+      podSecurityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        runAsGroup: 1000
+        fsGroup: 1000
+        seccompProfile:
+          type: RuntimeDefault
+
+    # Agent injector configuration
+    agentInjector:
+      # Enable the agent injector
+      enabled: true
+
+      # Resource limits and requests
+      resources:
+        requests:
+          cpu: 50m
+          memory: 64Mi
+        limits:
+          cpu: 200m
+          memory: 256Mi
+
+      # Security context
+      securityContext:
+        allowPrivilegeEscalation: false
+        readOnlyRootFilesystem: true
+        runAsNonRoot: true
+        runAsUser: 1000
+        runAsGroup: 1000
+        capabilities:
+          drop: [ALL]
+
+      # Pod security context
+      podSecurityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        runAsGroup: 1000
+        fsGroup: 1000
+        seccompProfile:
+          type: RuntimeDefault
+
+    # Global configuration
+    global:
+      # Image pull policy
+      imagePullPolicy: IfNotPresent
+
+      # Pod annotations for monitoring
+      podAnnotations:
+        prometheus.io/scrape: "true"
+        prometheus.io/port: "8080"
+        prometheus.io/path: "/metrics"
+
+    # Service monitor for Prometheus (if available)
+    serviceMonitor:
+      enabled: false
+      # Uncomment if you want to enable monitoring
+      # enabled: true
+      # interval: 30s
+      # scrapeTimeout: 10s

--- a/kubernetes/apps/telepresence/telepresence-oss/app/kustomization.yaml
+++ b/kubernetes/apps/telepresence/telepresence-oss/app/kustomization.yaml
@@ -1,0 +1,5 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./helmrelease.yaml

--- a/kubernetes/apps/telepresence/telepresence-oss/ks.yaml
+++ b/kubernetes/apps/telepresence/telepresence-oss/ks.yaml
@@ -1,0 +1,20 @@
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app telepresence-oss
+  namespace: flux-system
+spec:
+  targetNamespace: telepresence
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  path: ./kubernetes/apps/telepresence/telepresence-oss/app
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+  wait: true
+  interval: 30m
+  retryInterval: 1m
+  timeout: 5m

--- a/kubernetes/flux/repositories/oci/kustomization.yaml
+++ b/kubernetes/flux/repositories/oci/kustomization.yaml
@@ -7,4 +7,5 @@ resources:
   - ./bjw-s.yaml
   - ./prometheus-community.yaml
   - ./spegel.yaml
+  - ./telepresence.yaml
   - ./weave-gitops.yaml

--- a/kubernetes/flux/repositories/oci/telepresence.yaml
+++ b/kubernetes/flux/repositories/oci/telepresence.yaml
@@ -1,0 +1,10 @@
+---
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: HelmRepository
+metadata:
+  name: telepresence
+  namespace: flux-system
+spec:
+  type: oci
+  interval: 5m
+  url: oci://ghcr.io/telepresenceio


### PR DESCRIPTION
## Summary
- Add GitOps configuration for Telepresence OSS v2.23.6 to enable local development and debugging capabilities
- Configure dedicated telepresence namespace with Istio integration and production-ready security settings

## Test plan
- [ ] Verify Flux reconciles the new telepresence namespace and HelmRelease
- [ ] Confirm Telepresence Traffic Manager deploys successfully
- [ ] Test telepresence connect functionality from developer workstations
- [ ] Validate service intercept capabilities work as expected

🤖 Generated with [opencode](https://opencode.ai)